### PR TITLE
Added current-event banner to project site

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ how your changes will render in realtime.
 ### Generating the static website
 Once you are done with your changes, you need to compile the static
 content for the website. This is what is actually hosted 
-on the Apache Beam website.
+on the Apache Airavata website.
 
 You can build the static content by running the following command in the root
 website directory:

--- a/content/about.html
+++ b/content/about.html
@@ -176,6 +176,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/community.html
+++ b/content/community.html
@@ -496,6 +496,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/consensusBuilding.html
+++ b/content/consensusBuilding.html
@@ -161,6 +161,9 @@ the work under the <a href="/docs/governance/lazyConsensus.html">lazy consensus<
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/development.html
+++ b/content/development.html
@@ -489,6 +489,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/get-involved.html
+++ b/content/get-involved.html
@@ -239,6 +239,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/gsoc.html
+++ b/content/gsoc.html
@@ -153,6 +153,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/index.html
+++ b/content/index.html
@@ -372,6 +372,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/lazy-consensus.html
+++ b/content/lazy-consensus.html
@@ -166,6 +166,9 @@ can take some time to get used to.</p>
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/learning.html
+++ b/content/learning.html
@@ -236,6 +236,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/logo.html
+++ b/content/logo.html
@@ -194,6 +194,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/mailing-list.html
+++ b/content/mailing-list.html
@@ -247,6 +247,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/content/submit-patch.html
+++ b/content/submit-patch.html
@@ -140,6 +140,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>

--- a/source/_includes/footer.html
+++ b/source/_includes/footer.html
@@ -41,6 +41,9 @@
                         Contributor</a></li>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
+                <a href="https://www.apache.org/events/current-event.html">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                </a>
             </div>
 
         </div>


### PR DESCRIPTION
> All PMCs are asked to help promote ApacheCon and other major Apache sponsored events by adding some form of img link to their homepages, in whatever place works best for your site navigation.  Once you add the code, no further changes needed (will be auto-updated to be the next upcoming event).

This change makes sure the Apache Airavata project is including this current-event banner.