### PR TITLE
AIRAVATA-3964 Fix broken source.html links in submit-patch and development pages

### DIFF
--- a/source/development.md
+++ b/source/development.md
@@ -166,7 +166,7 @@ id: development
                             <li> Set or export JAVA_HOME to point to JDK. For example in Ubuntu: export
                                 JAVA_HOME=/usr/lib/jvm/java-6-openjdk
                             </li>
-                            <li> Get Airavata source [checked out](source.html) from Airavata trunk.</li>
+                            <li> Get Airavata source [checked out](https://github.com/apache/airavata) from Airavata trunk.</li>
                         </ol>
 
                         <h3> Build the distribution </h3>

--- a/source/submit-patch.md
+++ b/source/submit-patch.md
@@ -11,7 +11,7 @@ title: Submit Patch
 <li>Create a sample that you can use for prototyping the feature or demonstrating the bug. If creating a sample is time consuming, write steps to reproduce the issue.</li>
 <li>Attach this sample to the JIRA issue if it’s representing a bug report.</li>
 <li>Setup a svn client in your system.</li>
-<li><a href="source.html">Checkout</a> the source code.</li>
+<li><a href="https://github.com/apache/airavata">Checkout</a> the source code.</li>
 <li>Make your changes</li>
 <li>Create the patch:<ul>
 <li>svn add <any_files_you_added></li>


### PR DESCRIPTION
Fixes AIRAVATA-3964

Replaces broken `source.html` links in submit-patch and development pages with the correct GitHub repository URL.