### PR TITLE
AIRAVATA-3967 Link to on-page source section instead of GitHub mirror

### DIFF
--- a/content/development.html
+++ b/content/development.html
@@ -206,7 +206,7 @@
                             <li> Set or export JAVA_HOME to point to JDK. For example in Ubuntu: export
                                 JAVA_HOME=/usr/lib/jvm/java-6-openjdk
                             </li>
-                            <li> Get Airavata source [checked out](#source) from Airavata trunk.</li>
+                            <li> Get Airavata source [checked out](https://gitbox.apache.org/repos/asf/airavata.git) from Airavata trunk.</li>
                         </ol>
 
                         <h3> Build the distribution </h3>

--- a/content/development.html
+++ b/content/development.html
@@ -206,7 +206,7 @@
                             <li> Set or export JAVA_HOME to point to JDK. For example in Ubuntu: export
                                 JAVA_HOME=/usr/lib/jvm/java-6-openjdk
                             </li>
-                            <li> Get Airavata source [checked out](https://github.com/apache/airavata) from Airavata trunk.</li>
+                            <li> Get Airavata source [checked out](#source) from Airavata trunk.</li>
                         </ol>
 
                         <h3> Build the distribution </h3>

--- a/source/development.md
+++ b/source/development.md
@@ -166,7 +166,7 @@ id: development
                             <li> Set or export JAVA_HOME to point to JDK. For example in Ubuntu: export
                                 JAVA_HOME=/usr/lib/jvm/java-6-openjdk
                             </li>
-                            <li> Get Airavata source [checked out](#source) from Airavata trunk.</li>
+                            <li> Get Airavata source [checked out](https://gitbox.apache.org/repos/asf/airavata.git) from Airavata trunk.</li>
                         </ol>
 
                         <h3> Build the distribution </h3>

--- a/source/development.md
+++ b/source/development.md
@@ -166,7 +166,7 @@ id: development
                             <li> Set or export JAVA_HOME to point to JDK. For example in Ubuntu: export
                                 JAVA_HOME=/usr/lib/jvm/java-6-openjdk
                             </li>
-                            <li> Get Airavata source [checked out](https://github.com/apache/airavata) from Airavata trunk.</li>
+                            <li> Get Airavata source [checked out](#source) from Airavata trunk.</li>
                         </ol>
 
                         <h3> Build the distribution </h3>


### PR DESCRIPTION
This update corrects the Airavata source checkout link by moving the change to the canonical source file (`source/development.md`) instead of modifying generated content.

- Updated the checkout link to point directly to the canonical GitBox repository (`https://gitbox.apache.org/repos/asf/airavata.git`) instead of a mirror or section anchor.
- Regenerated the static site content using Jekyll so the fix is reflected in `content/`.

Ensures the link is accurate, canonical, and persists across future site builds.