### PR TITLE
Fix collaborations page rendering duplicate closing HTML tags

### DIFF
--- a/content/collaborations.html
+++ b/content/collaborations.html
@@ -229,12 +229,6 @@
  </script>
  --></p>
 
-<p>&lt;/body&gt;
- &lt;/html&gt;</p>
-
-<p>&lt;/body&gt;
- &lt;/html&gt;</p>
-
   		</article>
   	</div></main>
 

--- a/source/collaborations.md
+++ b/source/collaborations.md
@@ -160,10 +160,3 @@ id: collaborations
    src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDAe64UN6rxbgDo8hzspyTofIGXBiNcE_U&sensor=false">
  </script>
  -->
- 
- </body>
- </html>
- 
- 
- </body>
- </html>


### PR DESCRIPTION
Fix rendering issue on the collaborations page where raw `</body></html>` was visible in the UI.

**Cause:** Duplicate closing tags were present in the page source (`source/collaborations.md`). The layout already provides `</body>` and `</html>`, so the copies inside the content were emitted as text.

**Changes:**
- Removed duplicate `</body>` / `</html>` from `source/collaborations.md`
- Updated `content/collaborations.html` to match (no visible closing tags in content area)
<img width="1233" height="475" alt="Screenshot 2026-03-18 at 10 50 49 AM" src="https://github.com/user-attachments/assets/8ac5ba50-1738-4ebf-ae78-e4b921f0402e" />
