### PR TITLE
Fix HTML structure, broken links, typos, and accessibility across site

### DIFF
--- a/content/about.html
+++ b/content/about.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
     <title>Apache Airavata</title>
 
     <!-- CSS  -->
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li  class="active" ><a href="about.html">About</a></li>
@@ -75,7 +76,7 @@
     		<div class="row">
 
     <div class="col m4 center">
-        <img src="assets/img/airavata-logo.png" width="100%" />
+        <img src="assets/img/airavata-logo.png" width="100%" alt="Apache Airavata logo" />
     </div>
     <div class="col m8">
         <h3 class="airavata-grey">Apache Airavata</h3>
@@ -86,7 +87,7 @@
     <div class="col s12 m9 l10 push-m3 push-l2">
       <div id="legacy" class="section scrollspy">
         <h2 class="header">Legacy</h2>
-        <h4>LEAD Sience Gateway</h4>
+        <h4>LEAD Science Gateway</h4>
         <p>
             LEAD has pioneered new approaches for integrating, modeling, and mining complex weather data and Cyberinfrastructure systems to enable faster-than-real-time severe weather forecasts. 
             LEAD goals required to create a dynamically adaptive, on-demand, grid-enabled workflow system supporting long running applications and on-demand computing. LEAD has subsequently produced close to 450 research publications combined in all disciplines. The resulting software framework was built on the concepts of service oriented architectures powering the LEAD Gateway Portal.
@@ -125,7 +126,7 @@
 
   </div>
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -139,7 +140,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -177,7 +178,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -197,9 +198,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/collaborations.html
+++ b/content/collaborations.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
     <title>Apache Airavata</title>
 
     <!-- CSS  -->
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -130,7 +131,7 @@
                  <td>Materials Research</td>
              </tr>
              <tr>
-                 <td><a href="http://searchsra.scigap.org/ " target="_blank">Searching-SRA Gateway</a></td>
+                 <td><a href="http://searchsra.scigap.org/" target="_blank">Searching-SRA Gateway</a></td>
                  <td>Bio-informatics and Biology</td>
              </tr>
              <tr>
@@ -213,29 +214,7 @@
      </div>
  </div>
 
-<p><!-- Bootstrap core JavaScript
- ================================================== -->
- <!-- Placed at the end of the document so the pages load faster -->
- <script src="js/jquery-1.9.1.min.js"></script>
- <script src="js/modernizr.custom.js"></script>
- <script src="js/masonry.pkgd.min.js"></script>
- <script src="js/bootstrap.min.js"></script></p>
-
-<script src="//assets.iu.edu/search/2.x/search.js"></script>
-
-<p><!--
- <script type="text/javascript"
-   src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDAe64UN6rxbgDo8hzspyTofIGXBiNcE_U&sensor=false">
- </script>
- --></p>
-
-<p>&lt;/body&gt;
- &lt;/html&gt;</p>
-
-<p>&lt;/body&gt;
- &lt;/html&gt;</p>
-
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -249,7 +228,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -287,7 +266,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -307,9 +286,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/community.html
+++ b/content/community.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
     <title>Apache Airavata</title>
 
     <!-- CSS  -->
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -499,7 +500,7 @@
 
 </div>
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -513,7 +514,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -551,7 +552,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -571,9 +572,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/consensusBuilding.html
+++ b/content/consensusBuilding.html
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>Building Consensus | Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -110,7 +111,7 @@ or not.</p>
 <p>Once there is a clear consensus members of the community can proceed with 
 the work under the <a href="https://community.apache.org/committers/lazyConsensus.html">lazy consensus</a> model.</p>
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -124,7 +125,7 @@ the work under the <a href="https://community.apache.org/committers/lazyConsensu
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -162,7 +163,7 @@ the work under the <a href="https://community.apache.org/committers/lazyConsensu
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -182,9 +183,9 @@ the work under the <a href="https://community.apache.org/committers/lazyConsensu
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/development.html
+++ b/content/development.html
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>Development | Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -96,7 +97,7 @@
                         <h3>Previous Releases</h3>
                         <p id="previous-releases-are-available-from-release-archive">
                             Previous releases are available from
-                            <a href="https//airavata.staging.apache.org/about/downloads-archive.html">Release Archive</a>. We encourage users
+                            <a href="https://airavata.staging.apache.org/about/downloads-archive.html">Release Archive</a>. We encourage users
                             and developers to upgrade to the current release.
                         </p>
                     </div>
@@ -121,14 +122,14 @@
 
                         <h3>Profiling and Performance</h3>
                         <p>
-                            Airavata developers use <a href="http://www.ej-technologies.com/products/jprofiler/overview.html" target="_blank">JProfiler</a>
+                            Airavata developers use <a href="https://www.ej-technologies.com/products/jprofiler/overview.html" target="_blank">JProfiler</a>
                             for code profiling and testing, and acknowledges free developer licenses provided by
                             ej-technologies.
                         </p>
 
                         <h3>Code Analysis</h3>
                         <p>
-                            Airavata uses <a href="http://www.sonarqube.org/" target="_blank">Sonar</a> code analysis
+                            Airavata uses <a href="https://www.sonarqube.org/" target="_blank">Sonar</a> code analysis
                             tools. Sonar is an open source quality management platform, dedicated to continuously
                             analyze and measure technical quality, from the project portfolio to the class method.
                         </p>
@@ -163,7 +164,7 @@
 
                         <p>The Apache Airavata source repositories are maintained using GIT version control. The repositories are mirrored in GitHub and are writable. 
                          For practicle purposes contributors and committers can use these repositories as yet another github repo. All user level github documentations applies. Some admin funcations on github may not work and Apache INFRA needs to be contacted for help with these tasks. </p>
-                        <p>Browse Airavata source repository on web: <a href="https://git-wip-us.apache.org/repos/asf?p=airavata.git">https://git-wip-us.apache.org/repos/asf?p=airavata.git</a>.
+                        <p>Browse Airavata source repository on web: <a href="https://gitbox.apache.org/repos/asf/airavata.git">https://gitbox.apache.org/repos/asf/airavata.git</a>.
                         </p>
                         <h3>Airavata Core Services</h3>
                         <ol>
@@ -174,7 +175,7 @@
                         <h3>Airavata PHP Gateway</h3>
                         <ol>
                             <li>
-                                <p><a href="https://github.com/apache/airavata-php-gateway.git">https://github.com/apache/airavata-php=gateway.git</a></p>
+                                <p><a href="https://github.com/apache/airavata-php-gateway.git">https://github.com/apache/airavata-php-gateway.git</a></p>
                             </li>
                         </ol>
                         <h3>Airavata Documentation</h3>
@@ -196,7 +197,7 @@
                     <div id="build" class="section scrollspy">
                         <h2>Building the Code</h2>
                         The following instructions will build and deploy Apache Airavata for testing and development.
-                        For a full, production environment gateway deployment, see <a href="http://airavata.readthedocs.io/en/latest/">http://airavata.readthedocs.io/en/latest/</a>.
+                        For a full, production environment gateway deployment, see <a href="https://airavata.readthedocs.io/en/latest/">https://airavata.readthedocs.io/en/latest/</a>.
                         <h3> Prerequisites </h3>
                         <ol>
                             <li>Sources compilation require Java SE 8 or higher.</li>
@@ -223,7 +224,7 @@
                         <h2>Developers Guide</h2>
                         <h3>Some coding practices:</h3>
                         <ol>
-                            <li>License Header: Always add the current ASF license header as described in <a href="http://www.apache.org/legal/src-headers.html">ASF Source Header</a>.
+                            <li>License Header: Always add the current ASF license header as described in <a href="https://www.apache.org/legal/src-headers.html">ASF Source Header</a>.
                             </li>
                             <li>Trailing Whitespaces: Remove all trailing whitespaces. Eclipse users can use Source-&gt;Cleanup
                                 option to accomplish this.
@@ -239,7 +240,7 @@
                         <h2 class="header">License</h2>
 
                         <p>Apache License<br /><br />Version 2.0, January 2004<br /><br />
-                            <a href="http://www.apache.org/licenses/">http://www.apache.org/licenses/</a>
+                            <a href="https://www.apache.org/licenses/">https://www.apache.org/licenses/</a>
                         </p>
                         <p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
                         <p><strong><a name="definitions">1. Definitions</a></strong>.</p>
@@ -457,7 +458,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -495,7 +496,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -515,9 +516,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/get-involved.html
+++ b/content/get-involved.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
     <title>Apache Airavata</title>
 
     <!-- CSS  -->
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -75,7 +76,7 @@
     		<div class="row">
 
   <div class="col s12 m4">
-      <img src="assets/img/contribute.png" width="100%" />
+      <img src="assets/img/contribute.png" width="100%" alt="Contributing to Apache Airavata" />
   </div>
   <div class="col s12 m8">
       <h3>Contribute to OpenSource</h3>
@@ -167,9 +168,9 @@
         <h4 id="the-review-process">The review process</h4>
         <p>The airavata community will need to review your pull request before it is merged. If we are slow to respond, feel free to also email the dev mailing list: dev@airavata.apache.org.    </p>
         <p>During the review process you may be asked to make some changes to your submission. While working through feedback, it can be beneficial to create new commits so the incremental change is obvious. This can also lead to a complex set of commits, and having an atomic change per commit is preferred in the end. Use your best judgement and work with your reviewer as to when you should revise a commit or create a new one.</p>
-        <p>A pull request is considered ready to be merged once it gets at lease one +1 from a reviewer. Once all the changes have been completed and the pull request is accepted, it must be rebased to the latest upstream version. It is also a good idea to squash all the commits into a single one, since this will allow us to generate a clean patch and merge it properly.</p>
+        <p>A pull request is considered ready to be merged once it gets at least one +1 from a reviewer. Once all the changes have been completed and the pull request is accepted, it must be rebased to the latest upstream version. It is also a good idea to squash all the commits into a single one, since this will allow us to generate a clean patch and merge it properly.</p>
         <h4 id="accepting-contributions">Accepting Contributions</h4>
-        <p>Developers with Airavata Commit access should read <a href="http://airavata.staging.apache.org/community/how-to-commit-contributed-code.html">Accepting Contribtions</a> on steps to accept the contributed code</p>
+        <p>Developers with Airavata Commit access should read <a href="http://airavata.staging.apache.org/community/how-to-commit-contributed-code.html">Accepting Contributions</a> on steps to accept the contributed code</p>
 
     </div>
   </div>
@@ -188,7 +189,7 @@
 </div>
 
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -202,7 +203,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -240,7 +241,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -260,9 +261,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/gsoc.html
+++ b/content/gsoc.html
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>GSoC | Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -65,7 +66,7 @@
 <div class="section no-pad-bot" id="gsoc-banner">
     <div class="container">
         <h1 class="center">
-            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;" />
+            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;" alt="Apache Airavata logo" />
         </h1>
     </div>
 </div>
@@ -116,7 +117,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -154,7 +155,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -174,9 +175,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/index.html
+++ b/content/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
     <title>Apache Airavata</title>
 
     <!-- CSS  -->
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -65,7 +66,7 @@
 <div class="section no-pad-bot" id="index-banner">
     <div class="container">
         <h1 class="center">
-            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;" />
+            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;" alt="Apache Airavata logo" />
         </h1>
         <h5 class="center white-text">
             Apache Airavata<sup>TM</sup> is a software framework that enables you to compose, manage, execute, and monitor large scale applications and workflows on distributed computing resources such as local clusters, supercomputers, computational grids, and computing clouds.
@@ -214,7 +215,7 @@
 
 <!--Parallax-->
 <div class="parallax-container valign-wrapper">
-    <div class="parallax"><img src="assets/img/keyboard-001.jpg" /></div>
+    <div class="parallax"><img src="assets/img/keyboard-001.jpg" alt="" /></div>
     <div class="row valign">
         <h3 class="center white-text"> Get Started with Airavata! Try a demo</h3>
         <div class="col s2 offset-s5">
@@ -346,7 +347,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -384,7 +385,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -404,9 +405,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/lazy-consensus.html
+++ b/content/lazy-consensus.html
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>Lazy Consensus | Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -113,9 +114,8 @@ the proposal before work begins. </p>
 mail - quick and easy to read and reassuring for the implementer. However, 
 remember, in a lazy consensus world silence is the equivalent to support. This
 can take some time to get used to.</p>
-<p>&lt;/article&gt;</p>
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -129,7 +129,7 @@ can take some time to get used to.</p>
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -167,7 +167,7 @@ can take some time to get used to.</p>
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -187,9 +187,9 @@ can take some time to get used to.</p>
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/learning.html
+++ b/content/learning.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
     <title>Apache Airavata</title>
 
     <!-- CSS  -->
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -129,25 +130,15 @@
         </div>
         <div class="col s12 m6">
 
-            <a href="http://i590-spring2016.airavata-courses.documentup.com/" target="_blank">
-                <div class="card medium">
+            <div class="card medium">
                     <div class="card-image waves-effect waves-block waves-light">
-                        <img class="activator" src="assets/img/course.jpg" />
+                        <img class="activator" src="assets/img/course.jpg" alt="Airavata course syllabus" />
                     </div>
                     <div class="card-content">
-                        <span class="card-title activator grey-text text-darken-4">View Course Syllabus
-                        <!--<i class="mdi-navigation-more-vert right"></i>-->
+                        <span class="card-title activator grey-text text-darken-4">Course Syllabus
                         </span>
-                        <!--<p><a href="#">This is a link</a></p>-->
                     </div>
-                    <!--
-                    <div class="card-reveal">
-                        <span class="card-title grey-text text-darken-4">Sub Title<i class="material-icons right">close</i></span>
-                        <p>Here is some more information about this product that is only revealed once clicked on.</p>
-                    </div>
-                    -->
                 </div>
-            </a>
         </div>
     </div>
     <div class="row" id="tutorials">
@@ -185,7 +176,7 @@
 </div>
 
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -199,7 +190,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -237,7 +228,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -257,9 +248,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/logo.html
+++ b/content/logo.html
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>About Logo | Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -157,7 +158,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -195,7 +196,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -215,9 +216,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/mailing-list.html
+++ b/content/mailing-list.html
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>Mailing Lists | Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -93,8 +94,8 @@
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?dev@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.incubator.airavata-dev">Markmail Archive</a></li>
-				<li><a href="http://mail-archives.apache.org/mod_mbox/incubator-airavata-dev/">Incubator Archive</a> at Apache (May 2011 to Septemeber 2012)</li>
+				<li><a href="https://markmail.org/search/+list:org.apache.incubator.airavata-dev">Markmail Archive</a></li>
+				<li><a href="https://mail-archives.apache.org/mod_mbox/incubator-airavata-dev/">Incubator Archive</a> at Apache (May 2011 to September 2012)</li>
 			</ul>
 		</td>
 	</tr>
@@ -141,7 +142,7 @@
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?users@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.airavata.users">Markmail Archive</a></li>
+				<li><a href="https://markmail.org/search/+list:org.apache.airavata.users">Markmail Archive</a></li>
 			</ul>
 		</td>
 	</tr>
@@ -166,7 +167,7 @@
 		<td>
 		<ul>
 			<li>https://lists.apache.org/list.html?architecture@airavata.apache.org"&gt;Apache&lt;/a&gt;</li>
-			<li><a href="http://markmail.org/search/+list:org.apache.airavata.architecture">Markmail Archive</a></li>
+			<li><a href="https://markmail.org/search/+list:org.apache.airavata.architecture">Markmail Archive</a></li>
 		</ul>
 		</td>
 	</tr>
@@ -188,7 +189,7 @@
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?issues@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.airavata.issues">Markmail Archive</a></li>
+				<li><a href="https://markmail.org/search/+list:org.apache.airavata.issues">Markmail Archive</a></li>
 			</ul>
 		</td>
 	</tr>
@@ -203,22 +204,22 @@
 	</tr>
 	<tr>
 		<td>Unsubscribe:</td>
-		<td> <a href="mailto:commits-unsubscribe@airavata.apache.org">commmits-unsubscribe@airavata.apache.org</a></td>
+		<td> <a href="mailto:commits-unsubscribe@airavata.apache.org">commits-unsubscribe@airavata.apache.org</a></td>
 	</tr>
 	<tr>
 		<td>Archives:</td>
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?commits@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.incubator.airavata-commits">Markmail Archive</a></li>
-				<li><a href="http://mail-archives.apache.org/mod_mbox/incubator-airavata-commits">Incubator Archive</a> at Apache (May 2011 to Septemeber 2012)</li>
+				<li><a href="https://markmail.org/search/+list:org.apache.incubator.airavata-commits">Markmail Archive</a></li>
+				<li><a href="https://mail-archives.apache.org/mod_mbox/incubator-airavata-commits">Incubator Archive</a> at Apache (May 2011 to September 2012)</li>
 			</ul>
 		</td>
 	</tr>
 </table>
 <p>Note: This is a notification only mailing list and all queries have to directed to user/dev/architecture lists as appropriate. </p>
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -232,7 +233,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -270,7 +271,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -290,9 +291,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/content/submit-patch.html
+++ b/content/submit-patch.html
@@ -5,7 +5,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>Submit Patch | Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">
@@ -28,7 +29,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li ><a href="about.html">About</a></li>
@@ -82,14 +83,15 @@
 <li><a href="https://github.com/apache/airavata">Checkout</a> the source code.</li>
 <li>Make your changes</li>
 <li>Create the patch:<ul>
-<li>svn add any_files_you_added</li>
+<li>svn add <any_files_you_added>&lt;/li&gt;
 <li>svn diff &gt; /tmp/fix-AIRAVATA-NNNN.patch</li>
-</ul>
-</li>
+&lt;/ul&gt;
+&lt;/li&gt;
 <li>Attach that file (/tmp/fix-AIRAVATA-NNNN.patch) to the JIRA</li>
-</ul>
+&lt;/ul&gt;
+</any_files_you_added></li></ul></li></ul>
 
-  		</article>
+  		</div>
   	</div></main>
 
 </div>
@@ -103,7 +105,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -141,7 +143,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 
@@ -161,9 +163,9 @@
 </footer>
 
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/source/_includes/footer.html
+++ b/source/_includes/footer.html
@@ -4,7 +4,7 @@
             <div class="col m5 s12">
                 <div class="col m4 right-align">
                     <a href="https://apache.org" target="_blank">
-                        <img src="assets/img/apache-logo.png" width="70%"/>
+                        <img src="assets/img/apache-logo.png" width="70%" alt="Apache Software Foundation logo"/>
                     </a>
                 </div>
                 <div class="col m8">
@@ -42,7 +42,7 @@
                     <li><a class="white-text" href="gsoc.html">Student GSoC Projects</a></li>
                 </ul>
                 <a href="https://www.apache.org/events/current-event.html">
-                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;">
+                    <img src="https://www.apache.org/events/current-event-125x125.png" style="padding-top:0.5em;" alt="Current Apache event">
                 </a>
             </div>
 

--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -2,7 +2,8 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
     <meta name="theme-color" content="#2196F3">
-    <title>Apache Airavata</title>
+    <meta name="description" content="Apache Airavata is a software framework for composing, managing, executing, and monitoring applications and workflows on distributed computing resources.">
+    <title>{% if page.title %}{{ page.title }} | {% endif %}Apache Airavata</title>
 
     <!-- CSS  -->
     <link href="assets/min/plugin-min.css" type="text/css" rel="stylesheet">

--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -19,7 +19,7 @@
           <div class="container">
               <div class="nav-wrapper">
                   <a href="index.html" id="logo-container" class="brand-logo">
-                      <img src="assets/img/airavata-brand.png" width="50%" />
+                      <img src="assets/img/airavata-brand.png" width="50%" alt="Apache Airavata" />
                   </a>
                   <ul class="right hide-on-med-and-down">
                       <li {% if page.id == "about" %} class="active" {% endif %}><a href="about.html">About</a></li>
@@ -58,9 +58,9 @@
 
     {% include footer.html %}
 
-  </body>
   <!--  Scripts-->
   <script src="assets/min/plugin-min.js"></script>
   <script src="assets/min/custom-min.js"></script>
 
+  </body>
 </html>

--- a/source/_layouts/page.html
+++ b/source/_layouts/page.html
@@ -13,7 +13,7 @@ layout: default
 
 	<main><div class="container">
     		{{ content }}
-  		</article>
+  		</div>
   	</div></main>
 
 </div>

--- a/source/about.md
+++ b/source/about.md
@@ -7,7 +7,7 @@ id: about
   <div class="row">
 
     <div class="col m4 center">
-        <img src="assets/img/airavata-logo.png" width="100%">
+        <img src="assets/img/airavata-logo.png" width="100%" alt="Apache Airavata logo">
     </div>
     <div class="col m8">
         <h3 class="airavata-grey">Apache Airavata</h3>

--- a/source/collaborations.md
+++ b/source/collaborations.md
@@ -62,7 +62,7 @@ id: collaborations
                  <td>Materials Research</td>
              </tr>
              <tr>
-                 <td><a href="http://searchsra.scigap.org/ " target="_blank">Searching-SRA Gateway</a></td>
+                 <td><a href="http://searchsra.scigap.org/" target="_blank">Searching-SRA Gateway</a></td>
                  <td>Bio-informatics and Biology</td>
              </tr>
              <tr>
@@ -144,26 +144,3 @@ id: collaborations
          </table>
      </div>
  </div>
- 
- 
- <!-- Bootstrap core JavaScript
- ================================================== -->
- <!-- Placed at the end of the document so the pages load faster -->
- <script src="js/jquery-1.9.1.min.js"></script>
- <script src="js/modernizr.custom.js"></script>
- <script src="js/masonry.pkgd.min.js"></script>
- <script src="js/bootstrap.min.js"></script>
- 
- <script src="//assets.iu.edu/search/2.x/search.js"></script>
- <!--
- <script type="text/javascript"
-   src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDAe64UN6rxbgDo8hzspyTofIGXBiNcE_U&sensor=false">
- </script>
- -->
- 
- </body>
- </html>
- 
- 
- </body>
- </html>

--- a/source/development.md
+++ b/source/development.md
@@ -77,14 +77,14 @@ id: development
                         <h3>Profiling and Performance</h3>
                         <p>
                             Airavata developers use <a
-                                href="http://www.ej-technologies.com/products/jprofiler/overview.html" target="_blank">JProfiler</a>
+                                href="https://www.ej-technologies.com/products/jprofiler/overview.html" target="_blank">JProfiler</a>
                             for code profiling and testing, and acknowledges free developer licenses provided by
                             ej-technologies.
                         </p>
 
                         <h3>Code Analysis</h3>
                         <p>
-                            Airavata uses <a href="http://www.sonarqube.org/" target="_blank">Sonar</a> code analysis
+                            Airavata uses <a href="https://www.sonarqube.org/" target="_blank">Sonar</a> code analysis
                             tools. Sonar is an open source quality management platform, dedicated to continuously
                             analyze and measure technical quality, from the project portfolio to the class method.
                         </p>
@@ -122,7 +122,7 @@ id: development
                         <p>The Apache Airavata source repositories are maintained using GIT version control. The repositories are mirrored in GitHub and are writable. 
                          For practicle purposes contributors and committers can use these repositories as yet another github repo. All user level github documentations applies. Some admin funcations on github may not work and Apache INFRA needs to be contacted for help with these tasks. </p>
                         <p>Browse Airavata source repository on web: <a
-                                href="https://git-wip-us.apache.org/repos/asf?p=airavata.git">https://git-wip-us.apache.org/repos/asf?p=airavata.git</a>.
+                                href="https://gitbox.apache.org/repos/asf/airavata.git">https://gitbox.apache.org/repos/asf/airavata.git</a>.
                         </p>
                         <h3>Airavata Core Services</h3>
                         <ol>
@@ -133,7 +133,7 @@ id: development
                         <h3>Airavata PHP Gateway</h3>
                         <ol>
                             <li>
-                                <p><a href="https://github.com/apache/airavata-php-gateway.git">https://github.com/apache/airavata-php=gateway.git</a></p>
+                                <p><a href="https://github.com/apache/airavata-php-gateway.git">https://github.com/apache/airavata-php-gateway.git</a></p>
                             </li>
                         </ol>
                         <h3>Airavata Documentation</h3>
@@ -156,7 +156,7 @@ id: development
                         <h2>Building the Code</h2>
                         The following instructions will build and deploy Apache Airavata for testing and development.
                         For a full, production environment gateway deployment, see <a
-                            href="http://airavata.readthedocs.io/en/latest/">http://airavata.readthedocs.io/en/latest/</a>.
+                            href="https://airavata.readthedocs.io/en/latest/">https://airavata.readthedocs.io/en/latest/</a>.
                         <h3> Prerequisites </h3>
                         <ol>
                             <li>Sources compilation require Java SE 8 or higher.</li>
@@ -184,7 +184,7 @@ id: development
                         <h3>Some coding practices:</h3>
                         <ol>
                             <li>License Header: Always add the current ASF license header as described in <a
-                                    href="http://www.apache.org/legal/src-headers.html">ASF Source Header</a>.
+                                    href="https://www.apache.org/legal/src-headers.html">ASF Source Header</a>.
                             </li>
                             <li>Trailing Whitespaces: Remove all trailing whitespaces. Eclipse users can use Source-&gt;Cleanup
                                 option to accomplish this.
@@ -200,7 +200,7 @@ id: development
                         <h2 class="header">License</h2>
 
                         <p>Apache License<br><br>Version 2.0, January 2004<br><br>
-                            <a href="http://www.apache.org/licenses/">http://www.apache.org/licenses/</a>
+                            <a href="https://www.apache.org/licenses/">https://www.apache.org/licenses/</a>
                         </p>
                         <p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
                         <p><strong><a name="definitions">1. Definitions</a></strong>.</p>

--- a/source/get-involved.md
+++ b/source/get-involved.md
@@ -6,7 +6,7 @@ id: get-involved
 <div class="row">
 
   <div class="col s12 m4">
-      <img src="assets/img/contribute.png" width="100%">
+      <img src="assets/img/contribute.png" width="100%" alt="Contributing to Apache Airavata">
   </div>
   <div class="col s12 m8">
       <h3>Contribute to OpenSource</h3>

--- a/source/gsoc.md
+++ b/source/gsoc.md
@@ -7,7 +7,7 @@ title: GSoC
 <div class="section no-pad-bot" id="gsoc-banner">
     <div class="container">
         <h1 class="center">
-            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;"/>
+            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;" alt="Apache Airavata logo"/>
         </h1>
     </div>
 </div>

--- a/source/index.md
+++ b/source/index.md
@@ -6,7 +6,7 @@ layout: default
 <div class="section no-pad-bot" id="index-banner">
     <div class="container">
         <h1 class="center">
-            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;"/>
+            <img src="assets/img/airavata-logo-shadow.png" style="width:30%;" alt="Apache Airavata logo"/>
         </h1>
         <h5 class="center white-text">
             Apache Airavata<sup>TM</sup> is a software framework that enables you to compose, manage, execute, and monitor large scale applications and workflows on distributed computing resources such as local clusters, supercomputers, computational grids, and computing clouds.
@@ -155,7 +155,7 @@ layout: default
 
 <!--Parallax-->
 <div class="parallax-container valign-wrapper">
-    <div class="parallax"><img src="assets/img/keyboard-001.jpg"></div>
+    <div class="parallax"><img src="assets/img/keyboard-001.jpg" alt=""></div>
     <div class="row valign">
         <h3 class="center white-text"> Get Started with Airavata! Try a demo</h3>
         <div class="col s2 offset-s5">

--- a/source/lazy-consensus.md
+++ b/source/lazy-consensus.md
@@ -44,4 +44,3 @@ the proposal before work begins. </p>
 mail - quick and easy to read and reassuring for the implementer. However, 
 remember, in a lazy consensus world silence is the equivalent to support. This
 can take some time to get used to.</p>
-   </article>

--- a/source/learning.md
+++ b/source/learning.md
@@ -59,25 +59,15 @@ id: learning
         </div>
         <div  class="col s12 m6">
 
-            <a href="http://i590-spring2016.airavata-courses.documentup.com/" target="_blank">
-                <div class="card medium">
+            <div class="card medium">
                     <div class="card-image waves-effect waves-block waves-light">
-                        <img class="activator" src="assets/img/course.jpg">
+                        <img class="activator" src="assets/img/course.jpg" alt="Airavata course syllabus">
                     </div>
                     <div class="card-content">
-                        <span class="card-title activator grey-text text-darken-4">View Course Syllabus
-                        <!--<i class="mdi-navigation-more-vert right"></i>-->
+                        <span class="card-title activator grey-text text-darken-4">Course Syllabus
                         </span>
-                        <!--<p><a href="#">This is a link</a></p>-->
                     </div>
-                    <!--
-                    <div class="card-reveal">
-                        <span class="card-title grey-text text-darken-4">Sub Title<i class="material-icons right">close</i></span>
-                        <p>Here is some more information about this product that is only revealed once clicked on.</p>
-                    </div>
-                    -->
                 </div>
-            </a>
         </div>
     </div>
     <div class="row" id="tutorials">

--- a/source/mailing-list.md
+++ b/source/mailing-list.md
@@ -25,8 +25,8 @@ title: Mailing Lists
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?dev@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.incubator.airavata-dev">Markmail Archive</a></li>
-				<li><a href="http://mail-archives.apache.org/mod_mbox/incubator-airavata-dev/">Incubator Archive</a> at Apache (May 2011 to Septemeber 2012)</li>
+				<li><a href="https://markmail.org/search/+list:org.apache.incubator.airavata-dev">Markmail Archive</a></li>
+				<li><a href="https://mail-archives.apache.org/mod_mbox/incubator-airavata-dev/">Incubator Archive</a> at Apache (May 2011 to September 2012)</li>
 			</ul>
 		</td>
 	</tr>
@@ -73,7 +73,7 @@ title: Mailing Lists
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?users@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.airavata.users">Markmail Archive</a></li>
+				<li><a href="https://markmail.org/search/+list:org.apache.airavata.users">Markmail Archive</a></li>
 			</ul>
 		</td>
 	</tr>
@@ -98,7 +98,7 @@ title: Mailing Lists
 		<td>
 		<ul>
 			<li>https://lists.apache.org/list.html?architecture@airavata.apache.org">Apache</a></li>
-			<li><a href="http://markmail.org/search/+list:org.apache.airavata.architecture">Markmail Archive</a></li>
+			<li><a href="https://markmail.org/search/+list:org.apache.airavata.architecture">Markmail Archive</a></li>
 		</ul>
 		</td>
 	</tr>
@@ -120,7 +120,7 @@ title: Mailing Lists
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?issues@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.airavata.issues">Markmail Archive</a></li>
+				<li><a href="https://markmail.org/search/+list:org.apache.airavata.issues">Markmail Archive</a></li>
 			</ul>
 		</td>
 	</tr>
@@ -135,15 +135,15 @@ title: Mailing Lists
 	</tr>
 	<tr>
 		<td>Unsubscribe:</td>
-		<td> <a href="mailto:commits-unsubscribe@airavata.apache.org">commmits-unsubscribe@airavata.apache.org</a></td>
+		<td> <a href="mailto:commits-unsubscribe@airavata.apache.org">commits-unsubscribe@airavata.apache.org</a></td>
 	</tr>
 	<tr>
 		<td>Archives:</td>
 		<td>
 			<ul>
 				<li><a href="https://lists.apache.org/list.html?commits@airavata.apache.org">Apache Lists Archive</a></li>
-				<li><a href="http://markmail.org/search/+list:org.apache.incubator.airavata-commits">Markmail Archive</a></li>
-				<li><a href="http://mail-archives.apache.org/mod_mbox/incubator-airavata-commits">Incubator Archive</a> at Apache (May 2011 to Septemeber 2012)</li>
+				<li><a href="https://markmail.org/search/+list:org.apache.incubator.airavata-commits">Markmail Archive</a></li>
+				<li><a href="https://mail-archives.apache.org/mod_mbox/incubator-airavata-commits">Incubator Archive</a> at Apache (May 2011 to September 2012)</li>
 			</ul>
 		</td>
 	</tr>


### PR DESCRIPTION
## Summary
Addresses multiple small issues found while reviewing the website repository.

**HTML structure:**
- Fixed orphan `</article>` tag in page layout (replaced with `</div>`)
- Removed stray `</article>` from lazy-consensus page
- Moved scripts before `</body>` in default layout
- Removed leftover standalone scripts and duplicate closing tags from collaborations page

**Broken / outdated links:**
- Fixed PHP gateway GitHub URL typo (`=` → `-`)
- Replaced deprecated `git-wip-us.apache.org` with `gitbox.apache.org`
- Removed dead DocumentUp link from learning page
- Fixed trailing whitespace in collaborations URL
- Upgraded HTTP links to HTTPS across development and mailing list pages

**Typos:**
- Fixed `commmits` → `commits` in mailing list unsubscribe mailto
- Fixed `Septemeber` → `September` (x2)

**Accessibility / SEO:**
- Added `alt` attributes to key images (layout, footer, homepage, about, get-involved, gsoc, learning)
- Added meta description tag
- Made page titles dynamic (per-page title | Apache Airavata)

**Note:**
There are further minor HTML changes that can be made including, but not limited to, misspelling and elements, but I have personally decided to scope this PR solely on the important fixes.

links to [AIRAVATA-3971](https://issues.apache.org/jira/browse/AIRAVATA-3971)