### PR TITLE
fix: Add missing privacy policy link to footer

### DIFF
--- a/source/_includes/footer.html
+++ b/source/_includes/footer.html
@@ -19,6 +19,8 @@
                         <li><a class="white-text" href="https://apache.org/foundation/sponsorship.html" target="_blank">Become
                             a Sponsor</a></li>
                         <li><a class="white-text" href="https://apache.org/security/" target="_blank">Security</a></li>
+                        <li><a class="white-text" href="https://privacy.apache.org/policies/privacy-policy-public.html"
+                               target="_blank">Privacy</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Links to the canonical ASF privacy policy URL per website policy.

Checker: https://whimsy.apache.org/site/